### PR TITLE
removing the compile step from package.json

### DIFF
--- a/packages/integration-objects/package.json
+++ b/packages/integration-objects/package.json
@@ -18,8 +18,6 @@
     "jest": "^26.5.3"
   },
   "scripts": {
-    "compile": "cds build/all",
-    "prepare": "yarn compile",
     "test": "yarn jest --coverage",
     "test:local": "yarn jest",
     "coverage": "yarn jest --coverage",

--- a/packages/integration-objects/package.json
+++ b/packages/integration-objects/package.json
@@ -23,13 +23,6 @@
     "coverage": "yarn jest --coverage",
     "start": "yarn cds run"
   },
-  "cds": {
-    "requires": {
-      "uaa": {
-        "kind": "xsuaa"
-      }
-    }
-  },
   "keywords": [
     "currency"
   ],


### PR DESCRIPTION
Removing the compile step as the integration objects need to be packaged with just the srv/ and /db and the compile step also generates the gen folder. All of these steps need to be done in the consuming application as the db needs to be determined based on what the consuming applications deems fit for the application.

Also removing the cds block as this would also need to be done in the consuming application.